### PR TITLE
AGE-209 : Added support to listen VCS information from ENVs

### DIFF
--- a/tracker/helper.go
+++ b/tracker/helper.go
@@ -1,0 +1,22 @@
+package tracker
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"os"
+)
+
+func addVCSAttributes(attributes []attribute.KeyValue) []attribute.KeyValue {
+	// Read MW_VCS_REPOSITORY_URL and MW_VCS_COMMIT_SHA environment variables
+	vcsRepositoryURL := os.Getenv("MW_VCS_REPOSITORY_URL")
+	vcsCommitSHA := os.Getenv("MW_VCS_COMMIT_SHA")
+
+	// Add their values as resource attributes
+	if vcsRepositoryURL != "" {
+		attributes = append(attributes, attribute.String("vcs.repository_url", vcsRepositoryURL))
+	}
+	if vcsCommitSHA != "" {
+		attributes = append(attributes, attribute.String("vcs.commit_sha", vcsCommitSHA))
+	}
+
+	return attributes
+}

--- a/tracker/log.go
+++ b/tracker/log.go
@@ -114,6 +114,9 @@ func (t *Logs) initLogs(ctx context.Context, c *Config) error {
 		}
 	}
 
+	// Adding VCS information to the resource attributes
+	attributes = addVCSAttributes(attributes)
+
 	resources, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(

--- a/tracker/metrics.go
+++ b/tracker/metrics.go
@@ -110,6 +110,9 @@ func (t *Metrics) initMetrics(ctx context.Context, c *Config) error {
 		}
 	}
 
+	// Adding VCS information to the resource attributes
+	attributes = addVCSAttributes(attributes)
+
 	resources, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(

--- a/tracker/tracing.go
+++ b/tracker/tracing.go
@@ -111,6 +111,9 @@ func (t *Traces) initTraces(ctx context.Context, c *Config) error {
 		}
 	}
 
+	// Adding VCS information to the resource attributes
+	attributes = addVCSAttributes(attributes)
+	
 	resources, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(


### PR DESCRIPTION
For OpsAI project,
We need VCS commit SHA & Repository URL information in resource attributes
Added that support via listening to these ENVs ...

MW_VCS_COMMIT_SHA
MW_VCS_REPOSITORY_URL